### PR TITLE
Node 10 API: Stop using deprecated Buffer methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,17 @@ node_js:
  - "6"
  - "7"
  - "8"
+ - "9"
+ - "10"
 install:
  - npm install
  - npm run compile
 script:
  - npm run lint
- - npm run coveralls
+ - npm run test
+
+jobs:
+  include:
+    - stage: after_success
+      script: npm run coveralls
+      node_js: 9

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm downloads](http://img.shields.io/npm/dm/token-types.svg)](https://npmjs.org/package/token-types)
 [![Dependencies](https://david-dm.org/Borewit/token-types.svg)](https://david-dm.org/Borewit/token-types)
 [![coveralls](https://coveralls.io/repos/github/Borewit/token-types/badge.svg?branch=master)](https://coveralls.io/github/Borewit/token-types?branch=master)
-
+[![NSP Status](https://nodesecurity.io/orgs/borewit/projects/a193313e-00be-4611-bcba-f68773e5704c/badge)](https://nodesecurity.io/orgs/borewit/projects/a193313e-00be-4611-bcba-f68773e5704c)
 A primitive token library used to read from, and to write a node `Buffer`.
 
 ### Tokens

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dependencies](https://david-dm.org/Borewit/token-types.svg)](https://david-dm.org/Borewit/token-types)
 [![coveralls](https://coveralls.io/repos/github/Borewit/token-types/badge.svg?branch=master)](https://coveralls.io/github/Borewit/token-types?branch=master)
 [![NSP Status](https://nodesecurity.io/orgs/borewit/projects/a193313e-00be-4611-bcba-f68773e5704c/badge)](https://nodesecurity.io/orgs/borewit/projects/a193313e-00be-4611-bcba-f68773e5704c)
+
 A primitive token library used to read from, and to write a node `Buffer`.
 
 ### Tokens

--- a/test/test-int16.ts
+++ b/test/test-int16.ts
@@ -11,7 +11,7 @@ describe("Parse 16-bit signed integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(2);
+            const buf = Buffer.alloc(2);
 
             Token.INT16_BE.put(buf, 0, 0x00);
             util.checkBuffer(buf, "0000");
@@ -25,7 +25,7 @@ describe("Parse 16-bit signed integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x0a\x1a\x00\x00\xff\xff\x80\x00', 'binary');
+            const buf = Buffer.from('\x0a\x1a\x00\x00\xff\xff\x80\x00', 'binary');
 
             assert.equal(Token.INT16_BE.get(buf, 0), 2586);
             assert.equal(Token.INT16_BE.get(buf, 2), 0);
@@ -39,7 +39,7 @@ describe("Parse 16-bit signed integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(2);
+            const buf = Buffer.alloc(2);
 
             Token.INT16_LE.put(buf, 0, 0x00);
             util.checkBuffer(buf, "0000");
@@ -53,7 +53,7 @@ describe("Parse 16-bit signed integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x1a\x0a\x00\x00\xff\xff\x00\x80', 'binary');
+            const buf = Buffer.from('\x1a\x0a\x00\x00\xff\xff\x00\x80', 'binary');
 
             assert.equal(Token.INT16_LE.get(buf, 0), 2586);
             assert.equal(Token.INT16_LE.get(buf, 2), 0);

--- a/test/test-int24.ts
+++ b/test/test-int24.ts
@@ -11,7 +11,7 @@ describe("Parse 24-bit signed integer", () => {
 
     it("should encode", () => {
 
-      const buf = new Buffer(3);
+      const buf = Buffer.alloc(3);
 
       Token.INT24_LE.put(buf, 0, 0x00);
       util.checkBuffer(buf, "000000");
@@ -25,7 +25,7 @@ describe("Parse 24-bit signed integer", () => {
 
     it("should decode", () => {
 
-      const buf = new Buffer('\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\x00\x80', 'binary');
+      const buf = Buffer.from('\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\x00\x80', 'binary');
 
       assert.equal(Token.INT24_LE.get(buf, 0), 0);
       assert.equal(Token.INT24_LE.get(buf, 3), -1);
@@ -39,7 +39,7 @@ describe("Parse 24-bit signed integer", () => {
 
     it("should encode", () => {
 
-      const buf = new Buffer(3);
+      const buf = Buffer.alloc(3);
 
       Token.INT24_BE.put(buf, 0, 0x00);
       util.checkBuffer(buf, "000000");
@@ -53,7 +53,7 @@ describe("Parse 24-bit signed integer", () => {
 
     it("should decode", () => {
 
-      const buf = new Buffer('\x00\x00\x00\xff\xff\xff\x10\x00\xff\x80\x00\x00', 'binary');
+      const buf = Buffer.from('\x00\x00\x00\xff\xff\xff\x10\x00\xff\x80\x00\x00', 'binary');
 
       assert.equal(Token.INT24_BE.get(buf, 0), 0);
       assert.equal(Token.INT24_BE.get(buf, 3), -1);

--- a/test/test-int32.ts
+++ b/test/test-int32.ts
@@ -11,7 +11,7 @@ describe("Parse 32-bit signed integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(4);
+            const buf = Buffer.alloc(4);
 
             Token.INT32_BE.put(buf, 0, 0x00);
             util.checkBuffer(buf, "00000000");
@@ -25,7 +25,7 @@ describe("Parse 32-bit signed integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x00\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\xff\x80\x00\x00\x00', 'binary');
+            const buf = Buffer.from('\x00\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\xff\x80\x00\x00\x00', 'binary');
 
             assert.equal(Token.INT32_BE.get(buf, 0), 0);
             assert.equal(Token.INT32_BE.get(buf, 4), -1);
@@ -40,7 +40,7 @@ describe("Parse 32-bit signed integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(4);
+            const buf = Buffer.alloc(4);
 
             Token.INT32_LE.put(buf, 0, 0x00);
             util.checkBuffer(buf, "00000000");
@@ -54,8 +54,8 @@ describe("Parse 32-bit signed integer", () => {
 
         it("should decode", () => {
 
-            // const buf = new Buffer('\x00\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\xff\x80\x00\x00\x00', 'binary');
-            const buf = new Buffer('\x00\x00\x00\x00\xff\xff\xff\xff\xff\x00\x10\x00\x00\x00\x00\x80', 'binary');
+            // const buf = Buffer.from('\x00\x00\x00\x00\xff\xff\xff\xff\x00\x10\x00\xff\x80\x00\x00\x00', 'binary');
+            const buf = Buffer.from('\x00\x00\x00\x00\xff\xff\xff\xff\xff\x00\x10\x00\x00\x00\x00\x80', 'binary');
 
             assert.equal(Token.INT32_LE.get(buf, 0), 0);
             assert.equal(Token.INT32_LE.get(buf, 4), -1);

--- a/test/test-int8.ts
+++ b/test/test-int8.ts
@@ -9,7 +9,7 @@ describe("Parse 8-bit signed integer (INT8)", () => {
 
   it("should encode", () => {
 
-    const buf = new Buffer(1);
+    const buf = Buffer.alloc(1);
 
     Token.INT8.put(buf, 0, 0x00);
     util.checkBuffer(buf, "00");
@@ -23,7 +23,7 @@ describe("Parse 8-bit signed integer (INT8)", () => {
 
   it("should decode", () => {
 
-    const buf = new Buffer('\x00\x7f\x80\xff\x81', 'binary');
+    const buf = Buffer.from('\x00\x7f\x80\xff\x81', 'binary');
 
     assert.equal(Token.INT8.get(buf, 0), 0);
     assert.equal(Token.INT8.get(buf, 1), 127);

--- a/test/test-iso-8859-1.ts
+++ b/test/test-iso-8859-1.ts
@@ -5,7 +5,7 @@ import {AnsiStringType} from "../src/index";
 describe("Decode ANSI-string (ISO-8859-1)", () => {
 
   function decode(v: string): string {
-    const buf = new Buffer(v, "binary");
+    const buf = Buffer.from(v, "binary");
     const ansiStr = new AnsiStringType(buf.length);
     return ansiStr.get(buf);
   }

--- a/test/test-uint16.ts
+++ b/test/test-uint16.ts
@@ -11,7 +11,7 @@ describe("Parse 16-bit unsigned integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(4);
+            const buf = Buffer.alloc(4);
 
             Token.UINT16_LE.put(buf, 0, 0x00);
             Token.UINT16_LE.put(buf, 2, 0xffaa);
@@ -28,7 +28,7 @@ describe("Parse 16-bit unsigned integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x1a\x00\x1a\x00\x1a\x00\x1a\x00', 'binary');
+            const buf = Buffer.from('\x1a\x00\x1a\x00\x1a\x00\x1a\x00', 'binary');
 
             assert.equal(Token.UINT16_LE.get(buf, 0), 0x001a);
             assert.equal(Token.UINT16_BE.get(buf, 2), 0x1a00);

--- a/test/test-uint24.ts
+++ b/test/test-uint24.ts
@@ -11,7 +11,7 @@ describe("Parse 24-bit unsigned integer", () => {
 
         it("should encode", () => {
 
-            const buf = new Buffer(3);
+            const buf = Buffer.alloc(3);
 
             Token.UINT24_LE.put(buf, 0, 0x00);
             util.checkBuffer(buf, "000000");
@@ -34,7 +34,7 @@ describe("Parse 24-bit unsigned integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x1a\x1a\x00\x1a\x1a\x00\x1a\x1a\x00\x1a\x1a\x00', 'binary');
+            const buf = Buffer.from('\x1a\x1a\x00\x1a\x1a\x00\x1a\x1a\x00\x1a\x1a\x00', 'binary');
 
             assert.equal(Token.UINT24_LE.get(buf, 0), 0x001a1a);
             assert.equal(Token.UINT24_BE.get(buf, 3), 0x1a1a00);

--- a/test/test-uint32.ts
+++ b/test/test-uint32.ts
@@ -11,7 +11,7 @@ describe("Parse 32-bit unsigned integer", () => {
 
         describe("encode", () => {
 
-            const buf = new Buffer(4);
+            const buf = Buffer.alloc(4);
 
             it("should encode big-endian", () => {
 
@@ -41,7 +41,7 @@ describe("Parse 32-bit unsigned integer", () => {
 
         it("should decode", () => {
 
-            const buf = new Buffer('\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00', 'binary');
+            const buf = Buffer.from('\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00\x1a\x00', 'binary');
 
             assert.equal(Token.UINT32_LE.get(buf, 0), 0x001a001a);
             assert.equal(Token.UINT32_BE.get(buf, 4), 0x1a001a00);

--- a/test/test-uint8.ts
+++ b/test/test-uint8.ts
@@ -9,7 +9,7 @@ describe("Parse 8-bit unsigned integer (UINT8)", () => {
 
     it("should encode", () => {
 
-        const buf = new Buffer(1);
+        const buf = Buffer.alloc(1);
 
         Token.UINT8.put(buf, 0, 0x00);
         util.checkBuffer(buf, "00");
@@ -23,7 +23,7 @@ describe("Parse 8-bit unsigned integer (UINT8)", () => {
 
     it("should decode", () => {
 
-        const buf = new Buffer('\x00\x1a\x01\xff', 'binary');
+        const buf = Buffer.from('\x00\x1a\x01\xff', 'binary');
 
         assert.equal(Token.UINT8.get(buf, 0), 0);
         assert.equal(Token.UINT8.get(buf, 1), 26);


### PR DESCRIPTION
Related: Borewit/music-metadata#85