### PR TITLE
If buffer length ( - 4 ) is bigger than offset, set offset to buffer.length - 4

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -179,6 +179,9 @@ export const UINT32_LE: IToken<number> = {
   len: 4,
 
   get(buf: Buffer, off: number): number {
+    if ((buf.length - 4) < off) {
+      off = buf.length - 4;
+    }
     return buf.readUInt32LE(off);
   },
 


### PR DESCRIPTION
According to the specs here: https://nodejs.org/api/buffer.html#buffer_buf_readuint32le_offset

offset needs to be smaller or equal than buffer.length - 4.

I have implemented your package music-metadata to extract information from song, and for one specific mp3 ( which is big file ) i receive error ( for apev2 ): Out of range for this UINT32_LE, as offset is bigger than buffer.length.

My PR is safeguard.
