### PR TITLE
Change `@tokenizer/token` into a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "url": "https://github.com/Borewit/token-types/issues"
   },
   "devDependencies": {
-    "@tokenizer/token": "^0.3.0",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^8.2.3",
     "@types/node": "^16.3.2",
@@ -58,6 +57,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@tokenizer/token": "^0.3.0",
     "ieee754": "^1.2.1"
   },
   "remarkConfig": {


### PR DESCRIPTION
Fix: Borewit/music-metadata#866