### PR TITLE
chore: make workflow run on pull request

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,5 +1,7 @@
 name: Node.js CI
-on: push
+on:
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
 
@@ -9,9 +11,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 16.x
 
@@ -28,7 +30,7 @@ jobs:
         run: yarn run build
 
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: |
@@ -46,15 +48,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
 
       - name: 'Checkout the repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test with Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -62,7 +64,7 @@ jobs:
         run: yarn install --ignore-engines
 
       - name: Download build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
 


### PR DESCRIPTION
Fixes #651

I also added testing on node v20 and bumped the action versions to avoid a bunch of out-of-date node version warnings.

