### PR TITLE
Use `@kayahr/text-encoding` text encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ import * as token from 'token-types';
 
 ### String tokens
 
-StringType decoding is implemented using [TextDecoder](https://developer.mozilla.org/docs/Web/API/TextDecoder),
-it has build-in support for [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) decoding.
+StringType decoding is using [@kayahr/text-encoding](https://github.com/kayahr/text-encoding).
 
-Check out [the MDN web docs for the TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/encoding) for a complete list
+Check out [Supported encodings](https://github.com/kayahr/text-encoding?tab=readme-ov-file#supported-encodings) for a complete list.
 
 ### Custom tokens
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,8 @@
 import * as ieee754 from 'ieee754';
 import type { IToken, IGetToken } from '@tokenizer/token';
 
+import { TextDecoder } from "@kayahr/text-encoding";
+
 // Primitive types
 
 function dv(array: Uint8Array) {
@@ -432,33 +434,15 @@ export class Uint8ArrayType implements IGetToken<Uint8Array> {
  * Supports all encodings supported by TextDecoder, plus 'windows-1252'.
  */
 export class StringType implements IGetToken<string> {
-  private decoder: (bytes: Uint8Array) => string;
-
-  private static readonly win1252Map = '\u20AC\u0081\u201A\u0192\u201E\u2026\u2020\u2021\u02C6\u2030\u0160\u2039\u0152\u008D\u017D\u008F\u0090\u2018\u2019\u201C\u201D\u2022\u2013\u2014\u02DC\u2122\u0161\u203A\u0153\u009D\u017E\u0178';
+  private textDecoder: TextDecoder;
 
   constructor(public len: number, encoding?: string) {
-    if (encoding && encoding.toLowerCase() === 'windows-1252') {
-      this.decoder = StringType.decodeWindows1252;
-    } else {
-      const textDecoder = new TextDecoder(encoding);
-      this.decoder = (bytes: Uint8Array) => textDecoder.decode(bytes);
-    }
+    this.textDecoder = new TextDecoder(encoding);
   }
 
   public get(data: Uint8Array, offset = 0): string {
     const bytes = data.subarray(offset, offset + this.len);
-    return this.decoder(bytes);
-  }
-
-  private static decodeWindows1252(bytes: Uint8Array): string {
-    let result = '';
-    for (let i = 0; i < bytes.length; i++) {
-      const byte = bytes[i];
-      result += byte < 0x80 || byte >= 0xA0
-        ? String.fromCharCode(byte)
-        : StringType.win1252Map[byte - 0x80];
-    }
-    return result;
+    return this.textDecoder.decode(bytes);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@kayahr/text-encoding": "^2.0.1",
     "@tokenizer/token": "^0.3.0",
     "ieee754": "^1.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,6 +205,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kayahr/text-encoding@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@kayahr/text-encoding@npm:2.0.1"
+  checksum: 10c0/1bb7f677eaac834b63a4e30f39421c53faab515db7bff072fd8b9c5b1b5a6f1694680b9241cd0e85dbf4b61cacc62653e16130f0469fe073388afb9783faa4bc
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3085,6 +3092,7 @@ __metadata:
   resolution: "token-types@workspace:."
   dependencies:
     "@biomejs/biome": "npm:2.1.4"
+    "@kayahr/text-encoding": "npm:^2.0.1"
     "@tokenizer/token": "npm:^0.3.0"
     "@types/chai": "npm:^5.2.2"
     "@types/mocha": "npm:^10.0.10"


### PR DESCRIPTION
 Use [@kayahr/text-encoding](https://github.com/kayahr/text-encoding) text encoder, to avoid problems with unsupported character sets.
 
 Related to:
 - https://github.com/Borewit/music-metadata/issues/2474